### PR TITLE
add base docker image for python3.8 and python3.10

### DIFF
--- a/base_python/python3.10/Dockerfile
+++ b/base_python/python3.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/base_python/python3.8/Dockerfile
+++ b/base_python/python3.8/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8-slim as compile-image
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    gcc curl 
+CMD bash


### PR DESCRIPTION
# Summary
- base python3.8 docker image for when cuda is not required